### PR TITLE
Use AppsCode Community License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,5 @@
 ## License
 
-Source code in this repository is dually licensed under the PolyForm Noncommercial License 1.0.0 and the AppsCode Free Trial License 1.0.0. You may obtain a copy of these Licenses at
+Source code in this repository, Binaries, Docker images and Charts produced by the build process are licensed under the AppsCode Community License 1.0.0. You may obtain a copy of the License at
 
- - [PolyForm-Noncommercial-1.0.0](https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md)
- - [AppsCode-Free-Trial-1.0.0](https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md)
+ - [AppsCode-Community-1.0.0](https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/deploy/helm2.sh
+++ b/deploy/helm2.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/deploy/helm3.sh
+++ b/deploy/helm3.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/deploy/script.sh
+++ b/deploy/script.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/fmt.sh
+++ b/hack/fmt.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/license/bash.txt
+++ b/hack/license/bash.txt
@@ -1,16 +1,13 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/hack/license/dockerfile.txt
+++ b/hack/license/dockerfile.txt
@@ -1,12 +1,10 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/license/go.txt
+++ b/hack/license/go.txt
@@ -1,11 +1,12 @@
 /*
 Copyright AppsCode Inc. and Contributors
-Licensed under the PolyForm Noncommercial License 1.0.0 and
-the AppsCode Free Trial License 1.0.0 (the "License"s);
-you may not use this file except in compliance with these Licenses.
-You may obtain a copy of these Licenses at
- - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
- - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+
+Licensed under the AppsCode Community License 1.0.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/hack/license/makefile.txt
+++ b/hack/license/makefile.txt
@@ -1,12 +1,10 @@
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/scripts/update-release-tracker.sh
+++ b/hack/scripts/update-release-tracker.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/templates/helm2.sh
+++ b/templates/helm2.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/templates/helm3.sh
+++ b/templates/helm3.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/templates/script.sh
+++ b/templates/script.sh
@@ -2,13 +2,11 @@
 
 # Copyright AppsCode Inc. and Contributors
 #
-# Licensed under the PolyForm Noncommercial License 1.0.0 and
-# the AppsCode Free Trial License 1.0.0 (the "License"s);
-# you may not use this file except in compliance with these Licenses.
-# You may obtain a copy of these Licenses at
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#  - https://github.com/appscode/licenses/raw/1.0.0/PolyForm-Noncommercial-1.0.0.md
-#  - https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Free-Trial-1.0.0.md
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This allows both commercial and non-commercial organizations use the Community Edition of this software.

Signed-off-by: Tamal Saha <tamal@appscode.com>